### PR TITLE
Fix caret symbol

### DIFF
--- a/src/HtmlParser.elm
+++ b/src/HtmlParser.elm
@@ -98,7 +98,7 @@ attributeQuotedValue =
 -- HTML5
 attributeBareValue : Parser s String
 attributeBareValue =
-  regex """[^ ^`^"^'^<^>^=^\n^\r^\t]+"""
+  regex """[^ `"'<>=\n\r\t]+"""
 
 
 attributeValue : Parser s String
@@ -252,12 +252,12 @@ entityString =
 
 textNodeNonEntityString : Parser s String
 textNodeNonEntityString =
-  regex "[^<^&]*"
+  regex "[^<&]*"
 
 
 attributeValueEntityString : String -> Parser s String
 attributeValueEntityString quote =
-  regex ("[^<^&^" ++ quote ++ "]*")
+  regex ("[^<&" ++ quote ++ "]*")
 
 
 singleNode : Parser s Node

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -29,6 +29,7 @@ textNodeTests =
     [ test "basic" (testParse "1" (Text "1"))
     , test "basic" (testParse "a" (Text "a"))
     , test "basic" (testParse "1a" (Text "1a"))
+    , test "basic" (testParse "^" (Text "^"))
     , test "decode" (testParse "&" (Text "&"))
     , test "decode" (testParse "&amp;" (Text "&"))
     , test "decode" (testParse "&lt;" (Text "<"))


### PR DESCRIPTION
So for some reason I couldn't parse anything that had the caret `^` symbol in it, this fixes that. Not sure if I took the correct approach, but here it is nonetheless 😄 

The test fails when you remove the applied fix in `src/HtmlParser.elm`.