### PR TITLE
Fix SVG viewBox attribute issue

### DIFF
--- a/src/HtmlParser.elm
+++ b/src/HtmlParser.elm
@@ -86,9 +86,26 @@ tagName =
   map String.toLower (regex "[a-zA-Z][a-zA-Z0-9\\-]*")
 
 
+specialCaseAttributes : Dict String String
+specialCaseAttributes =
+  Dict.fromList
+    [ ("viewbox", "viewBox")
+    ]
+
+
+normalizeAttribute : String -> String
+normalizeAttribute input =
+  let
+    lower =
+      String.toLower input
+  in
+    Dict.get lower specialCaseAttributes
+      |> Maybe.withDefault lower
+
+
 attributeName : Parser s String
 attributeName =
-  map String.toLower (regex "[a-zA-Z][a-zA-Z0-9:\\-]*")
+  map normalizeAttribute (regex "[a-zA-Z][a-zA-Z0-9:\\-]*")
 
 
 attributeQuotedValue : Parser s String

--- a/src/HtmlParser.elm
+++ b/src/HtmlParser.elm
@@ -86,7 +86,7 @@ tagName =
   map String.toLower (regex "[a-zA-Z][a-zA-Z0-9\\-]*")
 
 
-specialCaseAttributes : Dict String String
+specialCaseAttributes : Dict.Dict String String
 specialCaseAttributes =
   Dict.fromList
     [ ("viewbox", "viewBox")


### PR DESCRIPTION
SVG’s ‘viewBox’ attribute was being converted to the lowercase ‘viewbox’, which browsers don’t like.

Resolves #8.

Note I cannot run / update the test suite! It complains:

```
I cannot find module 'Test.Runner.Failure'.

Module 'Test.Reporter.Console.Format' is trying to import it.
```